### PR TITLE
Feature: Paginated Tabs

### DIFF
--- a/css/shell.css
+++ b/css/shell.css
@@ -131,6 +131,10 @@ li {
     color: green;
 }
 
+.tab-set {
+    width: 12px;
+}
+
 .tab-text {
     display: inline-block;
     width: 100px;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
                 <div id="header-placeholder"></div>
                 <ul id="tab-container">
                     <li id="new-tab" class="tab tab-new" onclick="onNewTab()"><i class="fa fa-plus tab-new-icon"></i></li>
+                    <li id="tab-set-next" class="tab tab-set fa fa-arrow-up" onclick="nextSet()"></li>
+                    <li id="tab-set-prev" class="tab tab-set fa fa-arrow-down" onclick="prevSet()"></li>
                 </ul>
             </div>
             <!-- Container for UI buttons, url bar etc -->

--- a/js/shell.js
+++ b/js/shell.js
@@ -98,6 +98,14 @@ window.onload = function() {
         this.activate = function() {
             this.label.classList.add("tab-active");
             this.iframe.classList.remove("hidden");
+            // switch the tabs to the page that this tab is on
+            for(var i in g_Tabs) {
+                if(g_Tabs[i] == this) {
+                    console.log("Found this tab");
+                    cur_tab_set = Math.floor(i / calcMaxTabs());
+                    break;
+                }
+            }
             updateUi();
         };
         this.deactivate = function() {
@@ -216,7 +224,7 @@ window.onload = function() {
         i_min = cur_tab_set * max_tabs
         i_max = i_min + max_tabs;
         console.log("updating UI "+i_min+" "+i_max);
-        for(i in g_Tabs) {
+        for(var i in g_Tabs) {
             console.log("i: "+i);
             if(i < i_min || i >= i_max){
                 console.log("hiding "+i);

--- a/js/shell.js
+++ b/js/shell.js
@@ -101,7 +101,6 @@ window.onload = function() {
             // switch the tabs to the page that this tab is on
             for(var i in g_Tabs) {
                 if(g_Tabs[i] == this) {
-                    console.log("Found this tab");
                     cur_tab_set = Math.floor(i / calcMaxTabs());
                     break;
                 }
@@ -223,14 +222,10 @@ window.onload = function() {
         max_tabs = calcMaxTabs();
         i_min = cur_tab_set * max_tabs
         i_max = i_min + max_tabs;
-        console.log("updating UI "+i_min+" "+i_max);
         for(var i in g_Tabs) {
-            console.log("i: "+i);
             if(i < i_min || i >= i_max){
-                console.log("hiding "+i);
                 g_Tabs[i].hideLabel();
             } else {
-                console.log("showing "+i);
                 g_Tabs[i].showLabel();
             }
         }

--- a/js/shell.js
+++ b/js/shell.js
@@ -301,10 +301,16 @@ window.onload = function() {
         getActiveTab().back();
     }
 
+    onResize = function() {
+        getActiveTab().activate();
+    }
+
     getUrlBar = function() {
         return document.getElementById("header-url");
     }
 
     // Create initial tab
     createAndAddTab("about:blank");
+
+    window.addEventListener("resize", onResize);
 }

--- a/js/shell.js
+++ b/js/shell.js
@@ -1,5 +1,6 @@
 window.onload = function() {
     g_Tabs = []
+    cur_tab_set = 0;
 
     var Tab = function(url) {
         this.url = url;
@@ -103,6 +104,12 @@ window.onload = function() {
             this.iframe.classList.add("hidden");
             this.label.classList.remove("tab-active");
         };
+        this.hideLabel = function() {
+            this.label.classList.add("hidden");
+        }
+        this.showLabel = function() {
+            this.label.classList.remove("hidden");
+        }
         this.reload = function() {
             try {
                 this.iframe.reload();
@@ -187,6 +194,7 @@ window.onload = function() {
             var nextTab = g_Tabs[nextIndex];
             nextTab.activate();
         }
+        updateUi();
     }
 
     onNewTab = function() {
@@ -202,6 +210,65 @@ window.onload = function() {
         var tab = getActiveTab();
         getUrlBar().value = tab.url;
         document.title = tab.titleText.nodeValue;
+
+        // only show the label for tabs of the page we're on
+        max_tabs = calcMaxTabs();
+        i_min = cur_tab_set * max_tabs
+        i_max = i_min + max_tabs;
+        console.log("updating UI "+i_min+" "+i_max);
+        for(i in g_Tabs) {
+            console.log("i: "+i);
+            if(i < i_min || i >= i_max){
+                console.log("hiding "+i);
+                g_Tabs[i].hideLabel();
+            } else {
+                console.log("showing "+i);
+                g_Tabs[i].showLabel();
+            }
+        }
+
+        // hide the previous button if we're on the first page
+        prev_btn =  document.getElementById("tab-set-prev");
+        if(cur_tab_set == 0) {
+            prev_btn.classList.add("hidden");
+        } else {
+            prev_btn.classList.remove("hidden");
+        }
+
+        // hide the next button if we're on the last page
+        next_btn = document.getElementById("tab-set-next");
+        if(i_max >= g_Tabs.length) {
+            next_btn.classList.add("hidden");
+        } else {
+            next_btn.classList.remove("hidden");
+        }
+    }
+
+    calcMaxTabs = function() {
+        // TODO: replace with document.width once it exists
+        windowWidth = document.getElementsByTagName("body")[0].getBoundingClientRect().width;
+        
+        // magic numbers, i know. this is supposed to be:
+        // width of the window, minus the width of the buttons that are always visible (new tab)
+        // divided by the width of an individual tab
+        return Math.floor((windowWidth - 80) / 158)
+    }
+
+    prevSet = function() {
+        if(cur_tab_set == 0) {
+            return
+        }
+        cur_tab_set--;
+        updateUi();
+    }
+
+    nextSet = function() {
+        max_tabs = calcMaxTabs();
+        if(g_Tabs.length / max_tabs < cur_tab_set + 1) {
+            return;
+        }
+        cur_tab_set++;
+        updateUi();
     }
 
     onReload = function() {


### PR DESCRIPTION
This feature is to add pagination to the tab list of servo-shell.

![servo-shell paginated tabs example](https://i.imgur.com/Ssn5dQU.jpg)
## Internal Overview

This feature works by:
- determining how many tabs can fit in a single row (see `calcMaxTabs()`)
- breaking g_Tabs down into pages, each with a set of tabs not to exceed `calcMaxTabs()` in quantity
- storing which page we are on in a global
- on every `updateUI()`,
  - `.hideLabel()` all the tabs not on this page, and `.showLabel()` all the tabs on this page
  - hide the back button if we are on the first page
  - hide the next button if we are on the last page
- on every window resize, calculate which page the current tab is on, and `updateUi()` to keep the tab list focused on it
## Design goals

I originally intended to implement chrome-style tabs with every tab in the window visible, with the new tab button to the side. However, this is difficult without flexbox (which Servo does not currently support), or a lot of JS.

I then intended to implement firefox-style tabs that scroll horizontally with arrows placed alongside the tabs. This is difficult without layout support for css's calc(), or a number of CSS hacks. Servo also does not have proper support for overflow:hidden (or maybe I was just using it wrong? My tests worked properly in chrome). A list would overlap the buttons placed alongside it.

This was the simplest compromise using the features that Servo currently supports, and I still had to work around a few quirks.
## Known bugs or design faults:
- ~~`calcMaxTabs()` depends on magic numbers to determine the width of a tab and the width of the create a new tab + page navigation buttons. This is not a bug in itself, but it will create bugs if the width of any of these ever change. It may be possible to fix this currently using getBoundingClientRect(), but that solution will be a bit messy.~~ this issue is partially resolved in adea000
